### PR TITLE
Add sidebar navigation

### DIFF
--- a/main.py
+++ b/main.py
@@ -136,13 +136,25 @@ state.setdefault("api_sel",  None)      # выбранный API-профиль
 state.setdefault("chat",     [])        # [(role, text)]
 
 # ══════════════════════════════════════════════════════════════════
-#  TAB DEFINITIONS                                                  #
+#  SIDEBAR NAVIGATION                                               #
 # ══════════════════════════════════════════════════════════════════
-tab_chat, tab_convert, tab_projects, tab_setup = st.tabs(
-    ["💬 Chat", "🔄 Convert", "🗂 Projects", "⚙️ API Setup"])
+PAGES = ["💬 Chat", "🔄 Convert", "🗂 Projects", "⚙️ API Setup"]
+state.setdefault("page", PAGES[0])
+
+for p in PAGES:
+    if st.sidebar.button(p, use_container_width=True,
+                         type="primary" if state["page"] == p else "secondary"):
+        state["page"] = p
+page = state["page"]
+
+# highlight selected project
+if state.get("proj_sel"):
+    st.sidebar.success(f"Проект: {state['proj_sel']}")
+else:
+    st.sidebar.info("Проект не выбран")
 
 # ───────────────────────────────────────────────────── Projects ───
-with tab_projects:
+if page == "🗂 Projects":
     st.header("🗂 Управление проектами")
 
     proj_names = list(state["projects"])
@@ -176,7 +188,7 @@ with tab_projects:
             st.write(f"{badge} **{api_name}**  —  {cfg['url']}  (:{cfg['port']})")
 
 # ───────────────────────────────────────────────────── API Setup ──
-with tab_setup:
+elif page == "⚙️ API Setup":
     st.header("⚙️ Настройка API-профиля")
     if not state["proj_sel"]:
         st.info("Создайте/выберите проект во вкладке «Projects».")
@@ -225,7 +237,7 @@ with tab_setup:
                      "\n".join(api["logs"][-20:]), height=200)
 
 # ───────────────────────────────────────────────────── CONVERT ───
-with tab_convert:
+elif page == "🔄 Convert":
     st.header("🔄 Загрузка OpenAPI и запуск MCP")
     if not state["proj_sel"] or not state["api_sel"]:
         st.info("Выберите проект и API во вкладке «API Setup».")
@@ -306,7 +318,7 @@ with tab_convert:
                  height=200)
 
 # ───────────────────────────────────────────────────── CHAT ──────
-with tab_chat:
+elif page == "💬 Chat":
     st.header("💬 Тестовый чат с MCP")
 
     # список всех запущенных серверов


### PR DESCRIPTION
## Summary
- replace tab layout with sidebar navigation
- show the current project in the sidebar
- use buttons instead of radio selection

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684de24e50cc8333ba47c623f90b7737