### PR TITLE
Improve Streamlit button layout

### DIFF
--- a/main.py
+++ b/main.py
@@ -134,18 +134,26 @@ state.setdefault("projects", {})        # name → project-dict
 state.setdefault("proj_sel", None)      # выбранный проект
 state.setdefault("api_sel",  None)      # выбранный API-профиль
 state.setdefault("chat",     [])        # [(role, text)]
+state.setdefault("api_library", {})    # глобальный каталог API
 
 # ══════════════════════════════════════════════════════════════════
 #  SIDEBAR NAVIGATION                                               #
 # ══════════════════════════════════════════════════════════════════
 PAGES = ["💬 Chat", "🔄 Convert", "🗂 Projects", "⚙️ API Setup"]
-page = st.sidebar.radio("Навигация", PAGES)
-
-# highlight selected project
-if state.get("proj_sel"):
-    st.sidebar.success(f"Проект: {state['proj_sel']}")
-else:
-    st.sidebar.info("Проект не выбран")
+state.setdefault("page", PAGES[0])
+with st.sidebar:
+    for p in PAGES:
+        if st.button(p, key=f"nav_{p}",
+                     type="primary" if state["page"] == p else "secondary",
+                     use_container_width=True):
+            state["page"] = p
+            rerun()
+    st.divider()
+    if state.get("proj_sel"):
+        st.success(f"Проект: {state['proj_sel']}")
+    else:
+        st.info("Проект не выбран")
+page = state["page"]
 
 # ───────────────────────────────────────────────────── Projects ───
 if page == "🗂 Projects":
@@ -160,26 +168,46 @@ if page == "🗂 Projects":
 
     project = {"name": "", "openai": OPENAI_ENV, "apis": {}} \
               if creating_new else state["projects"][chosen]
-    project["name"] = st.text_input("Название проекта", project["name"])
-    project["openai"] = st.text_input("OpenAI API-ключ",
-                                      project["openai"], type="password",
-                                      help="Пусто → берётся из .env")
-
-    if st.button("💾 Сохранить проект"):
-        if not project["name"]:
-            st.warning("Имя проекта обязательно.")
-        else:
-            state["projects"][project["name"]] = project
-            state["proj_sel"] = project["name"]
-            rerun()
+    with st.form("proj_form"):
+        project["name"] = st.text_input("Название проекта", project["name"])
+        project["openai"] = st.text_input("OpenAI API-ключ",
+                                          project["openai"], type="password",
+                                          help="Пусто → берётся из .env")
+        if st.form_submit_button("💾 Сохранить проект", type="primary",
+                                use_container_width=True):
+            if not project["name"]:
+                st.warning("Имя проекта обязательно.")
+            else:
+                state["projects"][project["name"]] = project
+                state["proj_sel"] = project["name"]
+                rerun()
 
     if not creating_new:
         st.divider()
         st.subheader("API-профили в проекте")
-        for api_name, cfg in project["apis"].items():
-            running = cfg.get("thread") and cfg["thread"].is_alive()
-            badge = "✅" if running else "⏹"
-            st.write(f"{badge} **{api_name}**  —  {cfg['url']}  (:{cfg['port']})")
+        for api_name, cfg in list(project["apis"].items()):
+            cols = st.columns([6, 1])
+            with cols[0]:
+                running = cfg.get("thread") and cfg["thread"].is_alive()
+                badge = "✅" if running else "⏹"
+                st.write(f"{badge} **{api_name}**  —  {cfg['url']}  (:{cfg['port']})")
+            with cols[1]:
+                if st.button("❌", key=f"del_{api_name}"):
+                    if running:
+                        st.warning("Остановите MCP перед удалением")
+                    else:
+                        project["apis"].pop(api_name)
+                        if state.get("api_sel") == api_name:
+                            state["api_sel"] = None
+                        rerun()
+
+        avail = [n for n in state["api_library"] if n not in project["apis"]]
+        if avail:
+            with st.form("attach_api_form"):
+                name = st.selectbox("Подключить API", avail)
+                if st.form_submit_button("➕ Добавить", type="primary", use_container_width=True):
+                    project["apis"][name] = copy.deepcopy(state["api_library"][name])
+                    rerun()
 
 # ───────────────────────────────────────────────────── API Setup ──
 elif page == "⚙️ API Setup":
@@ -196,30 +224,44 @@ elif page == "⚙️ API Setup":
                                      if state["api_sel"] in api_names else 0))
     creating_api = chosen_api == "< создать >"
 
+    template = None
+    if creating_api and state["api_library"]:
+        template = st.selectbox("Импортировать из библиотеки",
+                                ["<пусто>"] + list(state["api_library"]))
+
     api = {"name": "", "url": "", "port": 8000,
            "header_name": "", "header_val": "",
            "query_name": "", "query_val": "",
-           "spec": None, "enabled": {}, "thread": None, "logs": []} \
-          if creating_api else project["apis"][chosen_api]
+           "spec": None, "enabled": {}, "thread": None, "logs": []}
+    if not creating_api:
+        api.update(project["apis"][chosen_api])
+    elif template and template != "<пусто>":
+        api.update(copy.deepcopy(state["api_library"][template]))
 
-    col1, col2 = st.columns(2)
-    with col1:
-        api["name"] = st.text_input("API-имя", api["name"])
-        api["url"]  = st.text_input("URL спецификации", api["url"])
-        api["port"] = st.number_input("Порт MCP", 1024, 65535, api["port"])
-    with col2:
-        api["header_name"] = st.text_input("Auth header", api["header_name"])
-        api["header_val"]  = st.text_input("Header value", api["header_val"])
-        api["query_name"]  = st.text_input("Auth query", api["query_name"])
-        api["query_val"]   = st.text_input("Query value", api["query_val"])
+    with st.form("api_form"):
+        col1, col2 = st.columns(2)
+        with col1:
+            api["name"] = st.text_input("API-имя", api["name"])
+            api["url"]  = st.text_input("URL спецификации", api["url"])
+            api["port"] = st.number_input("Порт MCP", 1024, 65535, api["port"])
+        with col2:
+            api["header_name"] = st.text_input("Auth header", api["header_name"])
+            api["header_val"]  = st.text_input("Header value", api["header_val"])
+            api["query_name"]  = st.text_input("Auth query", api["query_name"])
+            api["query_val"]   = st.text_input("Query value", api["query_val"])
 
-    if st.button("💾 Сохранить API"):
-        if not api["name"] or not api["url"]:
-            st.warning("Заполните имя и URL спецификации.")
-        else:
-            project["apis"][api["name"]] = api
-            state["api_sel"] = api["name"]
-            rerun()
+        if st.form_submit_button("💾 Сохранить API", type="primary", use_container_width=True):
+            if not api["name"] or not api["url"]:
+                st.warning("Заполните имя и URL спецификации.")
+            else:
+                project["apis"][api["name"]] = api
+                clean = {k: api[k] for k in [
+                    "name", "url", "port", "header_name", "header_val",
+                    "query_name", "query_val", "spec", "enabled"
+                ]}
+                state["api_library"][api["name"]] = copy.deepcopy(clean)
+                state["api_sel"] = api["name"]
+                rerun()
 
     # отображаем короткие логи выбранного профиля
     if not creating_api:
@@ -241,7 +283,8 @@ elif page == "🔄 Convert":
     api = project["apis"][state["api_sel"]]
 
     # 1. Загрузка спецификации
-    if st.button("🔄 Скачать спецификацию"):
+    if st.button("🔄 Скачать спецификацию", type="primary",
+                 use_container_width=True):
         try:
             spec = load_openapi(api["url"])
         except Exception as e:
@@ -250,7 +293,6 @@ elif page == "🔄 Convert":
 
         gpt_describe(spec, project["openai"])
         api["spec"] = spec
-        # сформировать enabled map, если пусто
         eps = {(p, m.lower()) for p, v in spec["paths"].items() for m in v}
         if not api["enabled"]:
             api["enabled"] = {f"{m} {p}": True for (p, m) in eps}
@@ -260,16 +302,20 @@ elif page == "🔄 Convert":
     # 2. Выбор эндпоинтов
     if api.get("spec"):
         st.subheader("Включить/отключить эндпоинты")
-        cols = st.columns(2)
-        for i, (p, meths) in enumerate(api["spec"]["paths"].items()):
-            for m in meths:
-                key = f"{m} {p}"
-                with cols[i % 2]:
-                    api["enabled"][key] = st.checkbox(
-                        key, value=api["enabled"][key])
+        with st.form("mcp_form"):
+            cols = st.columns(2)
+            for i, (p, meths) in enumerate(api["spec"]["paths"].items()):
+                for m in meths:
+                    key = f"{m} {p}"
+                    with cols[i % 2]:
+                        api["enabled"][key] = st.checkbox(
+                            key, value=api["enabled"][key])
 
-        # 3. Запуск MCP
-        if st.button("🚀 Запустить / Перезапустить MCP"):
+            run_mcp = st.form_submit_button("🚀 Запустить / Перезапустить MCP",
+                                           type="primary",
+                                           use_container_width=True)
+
+        if run_mcp:
             allowed = {(p, m.lower()) for p, m in
                        [k.split(" ", 1)[::-1]
                         for k, v in api["enabled"].items() if v]}


### PR DESCRIPTION
## Summary
- group sidebar navigation with project info
- use forms for project and API editing
- wrap endpoint toggles and MCP restart in a form
- add ability to attach existing API profiles to projects
- store API profiles in a global library

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684df10267148333871a7b4fbfd296f4