### PR TITLE
Improve OpenAPI handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# OpenAPI cache
+spec_cache/
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore


### PR DESCRIPTION
## Summary
- cache downloaded specifications in `spec_cache`
- allow refreshing cached spec
- add viewer for stored spec
- ignore spec cache files

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684f4eaf12948333bdd87c7ecc58c457